### PR TITLE
Upgrade faraday to ~> 0.9.0

### DIFF
--- a/elasticsearch-client.gemspec
+++ b/elasticsearch-client.gemspec
@@ -18,8 +18,8 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency 'faraday', '~> 0.8'
-  s.add_dependency 'faraday_middleware', '~> 0.8.7'
+  s.add_dependency 'faraday', '~> 0.9'
+  s.add_dependency 'faraday_middleware', '~> 0.9'
   s.add_dependency 'excon'
   s.add_dependency 'yajl-ruby', '~> 1.1.0'
 

--- a/lib/elasticsearch/version.rb
+++ b/lib/elasticsearch/version.rb
@@ -1,3 +1,3 @@
 module ElasticSearch
-  VERSION = "0.1.1.ksr6"
+  VERSION = "0.1.1.ksr7"
 end


### PR DESCRIPTION
# WHAT

Upgrades `faraday` to `~> 0.9.0`.


# WHY

All part of my evil scheme to drop support for https://github.com/kickstarter/zendesk_api_client_rb.

# WHO

cc @christopherwright, @ktheory, @cainlevy 