### PR TITLE
Add "scroll" command, allowing efficient bulk pagination

### DIFF
--- a/lib/elasticsearch/version.rb
+++ b/lib/elasticsearch/version.rb
@@ -1,3 +1,3 @@
 module ElasticSearch
-  VERSION = "0.1.1.ksr8"
+  VERSION = "0.1.1.ksr9"
 end


### PR DESCRIPTION
See https://www.elastic.co/guide/en/elasticsearch/reference/0.90/search-request-scroll.html for details on the command itself

ping @cainlevy 