### PR TITLE
Update yajl-ruby dependency to get the fixes in 1.2.*

### DIFF
--- a/elasticsearch-client.gemspec
+++ b/elasticsearch-client.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'faraday', '~> 0.9'
   s.add_dependency 'faraday_middleware', '~> 0.9'
   s.add_dependency 'excon'
-  s.add_dependency 'yajl-ruby', '~> 1.1.0'
+  s.add_dependency 'yajl-ruby', '~> 1.2.0'
 
   s.add_development_dependency 'rake'
   s.add_development_dependency 'minitest'


### PR DESCRIPTION
### WHAT

Upgrad the `yajl-ruby` gem dependency from 1.1.* to 1.2.*

 ### WHY

There were some [fixes in 1.2.*](https://github.com/brianmario/yajl-ruby/compare/1.1.0...1.2.1), including [one for a segfault](https://github.com/brianmario/yajl-ruby/commit/c0f3ae21f124f360fa70418152b32f2b312d2bc8) that looks very similar to one I've observed in our app that uses this gem.

cc @cainlevy @christopherwright 