### PR TITLE
Support <1 and >1 versions of ES API, and start some api specs.

### DIFF
--- a/lib/elasticsearch/api.rb
+++ b/lib/elasticsearch/api.rb
@@ -204,8 +204,14 @@ module ElasticSearch
     #
     # Returns a hash, the parsed response body from elasticsearch
     def get_mapping(index, types)
+      path = if version_is_at_least("1.0")
+        "#{index}/_mapping/#{types}"
+      else
+        "#{index}/#{types}/_mapping"
+      end
+
       resp = get do |req|
-        req.url "#{index}/#{types}/_mapping"
+        req.url path
       end
       resp.body
     end
@@ -218,8 +224,14 @@ module ElasticSearch
     #
     # Returns a hash, the parsed response body from elasticsearch
     def put_mapping(index, type, mapping)
+      path = if version_is_at_least("1.0")
+        "#{index}/_mapping/#{type}"
+      else
+        "#{index}/#{type}/_mapping"
+      end
+
       resp = put do |req|
-        req.url "#{index}/#{type}/_mapping"
+        req.url path
         req.body = mapping
       end
       resp.body
@@ -292,6 +304,29 @@ module ElasticSearch
       resp.status == 200
     end
 
+    # Info about this ES cluster
+    #
+    # Returns a hash, for example:
+    # {
+    #   "status" : 200,
+    #   "name" : "my_node_name",
+    #   "cluster_name" : "my_elasticsearch_cluster",
+    #   "version" : {
+    #     "number" : "1.7.1",
+    #     "build_hash" : "abc123",
+    #     "build_timestamp" : "2015-01-01T00:00:00Z",
+    #     "build_snapshot" : false,
+    #     "lucene_version" : "4.10.4"
+    #   },
+    #   "tagline" : "You Know, for Search"
+    # }
+    def meta
+      resp = get do |req|
+        req.url '/'
+      end
+      resp.body
+    end
+
     # Initiates or continues a scrolling scan of the index.
     #
     # On the initial call a cursor (`_scroll_id`) is acquired, along with the first page of
@@ -324,5 +359,6 @@ module ElasticSearch
       end
       resp.body
     end
+
   end
 end

--- a/lib/elasticsearch/client.rb
+++ b/lib/elasticsearch/client.rb
@@ -44,7 +44,17 @@ module ElasticSearch
       @servers = @seed_servers.clone
       @current_server = @servers.first
       @refreshed_at = Time.now
+      @version = nil
       @connection = nil
+    end
+
+    # Returns the major/minor version
+    def version
+      @version ||= Gem::Version.new(meta['version']['number'])
+    end
+
+    def version_is_at_least(other_version)
+      version >= Gem::Version.new(other_version)
     end
 
     def fetch_servers

--- a/spec/api_spec.rb
+++ b/spec/api_spec.rb
@@ -1,0 +1,83 @@
+require_relative 'spec_helper'
+
+describe 'elasticsearch client' do
+  let(:servers) { ['http://127.0.0.1:9200'] }
+
+  subject do
+    ElasticSearch::Client.new(servers: servers)
+  end
+
+  it 'returns meta' do
+    subject.meta.must_be_instance_of Hash
+  end
+
+  it 'returns available?' do
+    subject.available?.must_equal true
+  end
+
+  it 'returns available?' do
+    subject.available?.must_equal true
+  end
+
+  it 'can fetch the indices' do
+    subject.get_aliases.must_be_instance_of Hash
+  end
+
+  it 'can create an index' do
+    with_temporary_index do |index_name|
+      subject.get_aliases.keys.must_include index_name
+    end
+  end
+
+  it 'can delete an index' do
+    with_temporary_index do |index_name|
+      subject.remove_index index_name
+      subject.get_aliases.keys.wont_include index_name
+    end
+  end
+
+  it 'can check for the existence of an index' do
+    with_temporary_index do |index_name|
+      subject.indices_exists?(index_name).must_equal true
+      subject.remove_index index_name
+      subject.indices_exists?(index_name).must_equal false
+    end
+
+  end
+
+  it 'can update and get a mapping' do
+    mapping =  {
+      "foo" => {
+        "properties" => {
+          "bar" => { "type" => "string", "store" => true }
+        }
+      }
+    }
+
+    with_temporary_index do |index_name|
+      response = subject.put_mapping index_name, 'foo', mapping
+      response["acknowledged"].must_equal true
+
+      response = subject.get_mapping index_name, 'foo'
+      response[index_name]["mappings"].must_equal mapping
+    end
+  end
+
+  def with_temporary_index(&blk)
+    index_name = "test_index_#{Time.now.to_i}"
+
+    begin
+      response = subject.create_index index_name
+      response["acknowledged"].must_equal true
+
+      yield index_name
+    ensure
+      if subject.indices_exists?(index_name)
+        response = subject.remove_index index_name
+        response["acknowledged"].must_equal true
+      end
+    end
+
+  end
+
+end

--- a/spec/elasticsearch_spec.rb
+++ b/spec/elasticsearch_spec.rb
@@ -15,6 +15,18 @@ describe 'elasticsearch client' do
     subject.should_refresh?.must_equal true
   end
 
+  it 'should return a version' do
+    subject.version.must_be_instance_of Gem::Version
+  end
+
+  it 'should be able to detect lower versions' do
+    subject.version_is_at_least('0.0.0').must_equal true
+  end
+
+  it 'should be able to detect higher versions' do
+    subject.version_is_at_least('999.0.0').must_equal false
+  end
+
   it 'defaults to seed servers when fetching' do
     subject.fetch_servers.must_equal servers
   end


### PR DESCRIPTION
### WHAT

* Support the changes that came [after 1.0 and onward](https://www.elastic.co/guide/en/elasticsearch/reference/current/breaking-changes.html)
* Add a `meta` method for getting verison and stuff
* Add some api specs